### PR TITLE
correct spelling of LightGBM

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Past Meetups
 * Aug 2021 [Austin](https://www.meetup.com/austinpython/events/280125340/) / [DC](https://www.meetup.com/dcpython/events/280125348/) - [Prefect](https://github.com/Jacob-Barhak/PrefectDemo) + [Video](https://youtu.be/vCqcr3FKf_I) by Jacob Barhak 
 * Sep 2021 [Austin](https://www.meetup.com/austinpython/events/280125393/) / [DC](https://www.meetup.com/dcpython/events/280125394/) - [Numba](https://github.com/numba/numba-examples/blob/master/notebooks/basics.ipynb) + [Video](https://youtu.be/dl8JnpO7vBY) by Stanley Seibert
 * Oct 2021 [Austin](https://www.meetup.com/austinpython/events/280412977/) / [DC](https://www.meetup.com/dcpython/events/280413140/) - [Prefetch](https://github.com/ambianic/peerfetch/blob/main/examples/helloworld/README.md) + [Video](https://youtu.be/LFKYtL1_RjQ) by Ivelin Ivanov
-* Nov 2021 [Austin](https://www.meetup.com/austinpython/events/280413061/) / [DC](https://www.meetup.com/dcpython/events/280413215/) - [light-GBM](https://github.com/jameslamb/lightgbm-dask-testing/blob/main/notebooks/demo.ipynb) + [Video](https://youtu.be/Yh-jK497VZU) by James Lamb
+* Nov 2021 [Austin](https://www.meetup.com/austinpython/events/280413061/) / [DC](https://www.meetup.com/dcpython/events/280413215/) - [LightGBM](https://github.com/jameslamb/lightgbm-dask-testing/blob/main/notebooks/demo.ipynb) + [Video](https://youtu.be/Yh-jK497VZU) by James Lamb
 
 
 


### PR DESCRIPTION
This pull request proposes a correction to the spelling of `LightGBM` in the entry about my recent talk on that project.

This is the spelling used at https://github.com/microsoft/LightGBM and in [the original paper](https://papers.nips.cc/paper/2017/hash/6449f44a102fde848669bdd9eb6b76fa-Abstract.html).

Thanks again for having me!